### PR TITLE
Fix error for react native

### DIFF
--- a/src/development.ts
+++ b/src/development.ts
@@ -10,7 +10,9 @@ function inIframe() {
   }
 }
 
-const IS_BROWSER = typeof window !== 'undefined'
+const IS_BROWSER = 
+  typeof window !== 'undefined' && 
+  window.navigator.product === 'Gecko'
 const IS_UNSUPPORTED_CONSOLE =
   IS_BROWSER &&
   /(\.stackblitz\.io|\.csb\.app)$/.test(location.host) &&

--- a/test/basic.test.tsx
+++ b/test/basic.test.tsx
@@ -20,7 +20,7 @@ describe('useTilg', () => {
     reset()
 
     expect(logs[0][0]).toEqual(
-      '\x1B[96m\x1B[1m<App/>\x1B[39m\x1B[22m rendered. Props: \x1B[96m\x1B[1m%o\x1B[39m\x1B[22m'
+      '\x1B[96m\x1B[1m<App/>\x1B[39m\x1B[22m rendered with props: \x1B[96m\x1B[1m%o\x1B[39m\x1B[22m.'
     )
     expect(logs[0][1]).toEqual({})
     expect(logs[1][0]).toEqual('\x1B[96m\x1B[1m<App/>\x1B[39m\x1B[22m mounted.')


### PR DESCRIPTION
The value of the [window.navigator.product](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/product)  property is always `Gecko`, in any browser.
However, in react native window.navigator.product returns `ReactNative`. 
```jsonc
// react native window object
{
  "console": { "reportErrorsAsExceptions": true },
  "__jsiExecutorDescription": "HermesRuntime",
  "nativeModuleProxy": {},
  "_WORKLET_RUNTIME": 105553139337248,
  "__reanimatedModuleProxy": {},
  "__BUNDLE_START_TIME__": 127407015.3367917,
  "__DEV__": true,
  "process": { "env": { "NODE_ENV": "development" } },
  "__METRO_GLOBAL_PREFIX__": "",
  "originalConsole": {},
  "ErrorUtils": {},
  "performance": {},
  "regeneratorRuntime": {},
  "originalRegeneratorRuntime": {},
  "navigator": { "product": "ReactNative" },
  "__SYSTRACE": {},
  "__ReactRefresh": {},
  "REACT_NAVIGATION_DEVTOOLS": {},
  "__react_navigation__elements_contexts": {}
}
```
So with this field, we can distinguish the browser and fix this issue.

**Before**

<img width="706" alt="image" src="https://user-images.githubusercontent.com/7110136/163026825-df11a1f9-1172-404a-9881-cb22d548ead5.png">
<img width="516" alt="image" src="https://user-images.githubusercontent.com/7110136/163028858-82a4ebd5-d9cf-4afd-873c-20d6aa3297a1.png">



**After**

<img width="712" alt="image" src="https://user-images.githubusercontent.com/7110136/163026841-1096071c-d237-4dca-8359-ea2d5732b69b.png">
<img width="516" alt="image" src="https://user-images.githubusercontent.com/7110136/163028877-0b138894-16ed-4ecc-99a3-5ef3bb47d9f5.png">

